### PR TITLE
Update link for Ambient Digital on sponsors page

### DIFF
--- a/djangocon_2025/site/views.py
+++ b/djangocon_2025/site/views.py
@@ -19,7 +19,7 @@ def default_view(request, menu="home", submenu=None):
         "Silver": [
             {
                 "name": "Ambient Digital",
-                "url": "https://ambientdigital.com.vn/",
+                "url": "https://ambient.digital/",
                 "logo": "images/sponsors/ambient.svg",
                 "filter": True,
             },


### PR DESCRIPTION
The link for Ambient Digital (where I work) on the sponsors page is incorrect, so I changed it :)