### PR TITLE
Code of conduct transparency report 

### DIFF
--- a/djangocon_2025/content/information/announcements/1transparencyreport.md
+++ b/djangocon_2025/content/information/announcements/1transparencyreport.md
@@ -1,5 +1,6 @@
 type: light-backgroud
 layout: composed
+
 <!--
 section: 25 November 2025
 

--- a/djangocon_2025/content/information/announcements/1transparencyreport.md
+++ b/djangocon_2025/content/information/announcements/1transparencyreport.md
@@ -1,10 +1,103 @@
-type: light-backgroud
+type: dark-background
 layout: composed
+section: 2025 Code of Conduct transparency report
 
-<!--
-section: 25 November 2025
+The [code of conduct team](/conduct/code_of_conduct/) is happy to share that we received no reports of potential code of conduct issues at this year’s DjangoCon Europe!
 
+Publishing this report is a part of our [Code of Conduct process](/conduct/response_guide/), which informs our work before, during, and after the conference. The report itself provides information about general team tasks, as well as incidents we handled.
 
-We will publish event announcements here.
-Stay tuned and follow us on X (formerly known as Twitter): <a href="https://twitter.com/djangoconeurope" class="pages-links">@DjangoConEurope</a>!
--->
+### The Code of Conduct and our Team
+
+The DjangoCon Europe Code of Conduct (CoC) and the workings of the team are directly taken from past events. For this year, there were three active people on the team:
+
+- Sunday Ajayi
+- Thibaud Colas
+- Vicky Twomey-Lee (Lead)
+
+### Before the conference
+
+Our team had two major tasks before the conference.
+
+#### Preparing for the event
+
+This generally meant doing anything we could ahead of the actual conference so our team could work as well as possible during the event:
+
+- Getting up to speed with general Code of Conduct team practices
+- Making sure we are familiar with moderation features across the different online platforms.
+- Confirming availability so we know we will have some presence throughout the whole conference, in person as well as online (Slack).
+
+The way to report code of conduct issues for our teams was set up on our behalf by other organisers: our team email address.
+
+Compared to past years, we didn’t reach out to the DSF Code of Conduct Committee as part of their [support for event organizers](https://github.com/django/code-of-conduct/blob/main/conferences.md). They advise sharing attendee and speaker details with the committee ahead of the event, but like in all past four djangoCon Europe events we decided against it as it seemed too problematic to do so while complying with personal data protection and privacy laws in Ireland. This long-standing issue is tracked in the Django code of conduct issues: [Compliance with privacy laws when working with conferences](https://github.com/django/code-of-conduct/issues/41). As per last year, we would follow the [conference privacy policy](https://2025.djangocon.eu/conduct/privacy_guide/) on how any personal data would be shared with the Django Software Foundation as part of any incident reports:
+
+> For code of conduct incident reports handling, we may collect additional information about individuals mentioned in any reports. We may share this information with the [Django Software Foundation Code of Conduct Committee](https://www.djangoproject.com/foundation/committees/#conduct) as needed. View our [Code of Conduct response guidelines](/conduct/response_guide/) for more information.
+
+#### Reviewing presentations from speakers
+
+With many scheduled presentations, this was a major task for us ahead of the event! All speakers were required to submit a draft version of their slides, ideally in the week before the conference, as complete as possible. In addition to the code of conduct review, this was also very helpful to live captioning providers as part of their preparations.
+
+This year, the CoC team requested all lighting talks to be emailed to the Code of Conduct email address for review, and will be allocated a slot on either of the conference days if the lightning talk passes the screening. This marks the first year we were able to review all pre-scheduled and all lightning talks given at the conference!
+
+Out of 35 talks and 27 lightning talks:
+
+- We reviewed 32 talks and 27 lightning talks without making comments
+- Two had small questionable references
+  - One was a line referring to a controversial historical figure quoted from a published paper in a slide which the speaker amended quite quickly. While this could be compatible with our Code of Conduct, we and the speaker felt it would be simpler and equally suitable to use another reference.
+  - The other was a question about a redacted swear word if that was a CoC problem. The Code of Conduct team will bear this in mind to keep swearing to a minimum. Note: This is not a CoC violation, though per the [code of conduct](https://2025.djangocon.eu/conduct/code_of_conduct/) excessive swearing isn’t acceptable.
+- 3 talks and 1 lightning talk were cancelled at various stages and therefore no longer relevant for review.
+
+Our highlights from this process are:
+
+- This review still feels very important even if there are no major issues to flag. It’s also important for there to be multiple reviewers to give the best chances of spotting issues ahead of time, and so the responsibility of spotting issues is shared.
+- All speakers that were present at the conference submitted their slides for review, some weeks ahead, some only at the last minute
+- All lightning talks slides were submitted for review. The speakers were all very patient,  understanding and supportive of the changes of this new process.
+- Having all the lightning talks reviewed and confirmed each day before the session means that we had a list of talk titles and speakers for the captioner. They were really thankful for this information in advance of each lightning talk session.
+
+As it was the first time this year for the Code of Conduct team to review lightning talk slides, it can be improved in the future to use a form to accept the lightning talks as it’s already managed through spreadsheets. Things to note from this year’s experience:
+
+- Some of the emails that were sent to the google group email ended up in a spam folder, therefore the reviewer had to check google groups, email inbox and spam folders. Having a form will mitigate this.
+- Replying via google groups is not ideal as it’s either to the coc team email or speaker, but not both.
+- Have an extra person help chasing down lightning talk speakers onsite. There were only two people onsite on Wednesday, and one person onsite on Friday (although there was support remotely in the latter case).
+
+All in all we’re elated to have been able to review all lightning talks for the first time ever, though this did significantly increase the code of conduct team’s workload during the conference, for what is already a small team. In the future, we will need to increase the active team size at the conference or share the workload with the programme team to make this sustainable.
+
+### During the conference
+
+Plain and simple, there were no incidents reported during the conference! Everyone involved played a part in fostering an excellent atmosphere throughout. The conference code of conduct was featured prominently, which helped set clear expectations for everyone.
+
+We received two suggestions or points of feedback during the conference:
+
+- One person flagging the “0 Code of Conduct incidents reported" statement at the end of the conference talks on Friday evening. This may create friction for people who might not want to feel like they burden the CoC team by providing the "first" report. This was followed up on Slack:
+  _“Quick reminder for everyone of the conference code of conduct! Our CoC team will be looking out for any reports over the coming days even after the conference is over. If there’s anything you would want to report please do go for it even if it’s been a few days”._
+  Future recommendations is to announce that no incidents were reported so far, and the CoC team will be checking for reports even after the conference is over. Or skip this type of announcement altogether, as there are many other good news to share at the end of the talks anyway.
+- One person flagged how participants who do not wish for their picture to be taken might still appear in video footage of the questions and answers section of the talks. We followed up with other organizers to confirm what their plan was for this footage. They explained this was setup in accordance with the conference room being divided in separate zones to respect people’s privacy, with the video footage only covering the expected half of the room. They reminded attendees of this setup later in the day and on other days.
+
+Everyone was equally excellent during the two-day sprint at the end of the conference and during the official social events, with the code of conduct still prominently featured on site and via reminders to attendees.
+
+### After the conference
+
+With the conference over, with no incidents reported during the event, our team’s remit was to:
+
+- Keep an eye out for any report sent to us after the conference.
+- Draft a report to Django’s own Code of Conduct Committee records.
+- Publish this transparency report.
+
+### Our takeaways for future events
+
+With no incidents to report (yay!), the best we can do is to share our main takeaways for future event organisers to learn from:
+
+- **A good team makes hard work feel easy.** We had excellent team dynamics, and excellent support from organisers and other volunteers.
+- **Compliance with data protection and privacy laws is no joke**. DjangoCon Europe handles personal details of hundreds of people, and we need to make sure we do so in a way that respects local law. This requires familiarity with said laws, and a bit of work to assess our processes.
+- **Lightning talks reviews are worthwhile but take a lot of work**. We need to invest more into the process ahead of time for future years, so it’s less reliant on time-consuming follow-ups.
+
+### About this report
+
+Even without any incidents to report on, we still believe publishing this report is a good way to show why our CoC is important, and how it is enforced in practice, in line with the transparency guidelines from Django’s CoC committee. We hope that by publishing this, we will encourage people to report incidents in the future, and that other conferences can learn from our mistakes and our successes.
+
+We welcome any feedback, and we would like to thank the DjangoCon Europe community – attendees, speakers, sponsors, and organisers alike – for working with us.
+
+We thank the organisers of DjangoCon Europe 2024 and 2023 for their transparency reports, which we followed as a template for this year’s report.
+
+The DjangoCon Europe 2025 Code of Conduct team,
+
+Sunday Ajayi, Thibaud Colas, Vicky Twomey-Lee (Lead)

--- a/djangocon_2025/static/css/project.css
+++ b/djangocon_2025/static/css/project.css
@@ -834,7 +834,7 @@ footer {
 }
 
 .content-container .simple-content a {
-  color: #003c80;
+  color: #97EB61;
 }
 
 .content-container .simple-content .btn {

--- a/djangocon_2025/templates/modules/credits.html
+++ b/djangocon_2025/templates/modules/credits.html
@@ -17,8 +17,6 @@
       />
       <h4 class="headtext">CODE OF CONDUCTS</h4>
      <h6 style="color: #bda712; font-weight: bold;">Vicky Twomey-Lee</h6>
-     <h6>Nana Adjoa Anim</h6>
-     <h6>Arafat Olayiwola</h6>
      <h6>Sunday Iyanu Ajayi</h6>
      <h6>Thibaud Colas </h6>
     </div>
@@ -99,8 +97,6 @@
       />
       <h4 class="headtext">SPONSORS</h4>
       <h6 style="color: #36bc5b; font-weight: bold">Luis Vaz</h6>
-       <h6>Abdul Muizz Ikumapayi</h6> 
-       <h6>Arafat Olayiwola</h6> 
        <h6>Mebarek Saf</h6> 
     </div>
 


### PR DESCRIPTION
Based on the team’s report handling, post-conference reflections, and participants’ feedback. Drafted by @whykay and reviewed + edited by me.

---

I’ve also updated the credits page, Nana and Arafat joined the team initially but they couldn’t make it to the conference in the end and didn’t end up being available / active during the conference or for the tasks in preparation for it.

Oh and fixed the colors of the links within this Markdown content, which otherwise is illegible with the site theme.